### PR TITLE
More idiomatic NodeJS local script running

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For a more up-to-date version, you can check out master:
 git clone https://github.com/pesterhazy/unravel.git
 cd unravel
 npm install
-scripts/run [--debug] <host> <port>
+npm run repl [--debug] <host> <port>
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "url": "https://github.com/pesterhazy/unravel/issues"
   },
   "homepage": "https://github.com/pesterhazy/unravel",
+  "scripts": {
+    "repl": "lumo -c src -m unravel.core \"$@\""
+  },
   "dependencies": {
     "historic-readline": "^1.0.8",
     "lumo-cljs": "1.2.0",


### PR DESCRIPTION
I don't have npm install -g working properly on my machine, and `npm run` is kind of a standard. By default, it runs with $folder/node_modules/.bin/ in its path (the other script calling lumo directly must have been referencing a previously installed version).